### PR TITLE
Fix: Add Jekyll front matter to modern-enhancements.css

### DIFF
--- a/css/modern-enhancements.css
+++ b/css/modern-enhancements.css
@@ -1,3 +1,7 @@
+---
+layout: null
+---
+
 /**
  * Modern CSS Enhancements
  * Adds modern features while maintaining compatibility with existing Beautiful Jekyll theme


### PR DESCRIPTION
The CSS file was missing Jekyll front matter (---layout: null---) which caused the site to fail loading. Jekyll needs this to properly process and serve the CSS file.

Please note that if you are trying to update **your** website, this is the wrong place to do so. Please carefully follow the Beautiful Jekyll instructions (found at https://github.com/daattali/beautiful-jekyll#readme) and make sure you submit changes to **your** version of the project.

If your intention is to submit a Pull Request, please describe what your pull request achieves.

Thank you!
