### PR TITLE
Enable Google Analytics 4 tracking

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -98,7 +98,7 @@ url-pretty: "github.com/Edudeiko"  # eg. "deanattali.com/beautiful-jekyll"
 # --- Web Statistics Section --- #
 
 # Fill in your Google Analytics gtag.js ID to track your website using gtag
-# gtag: ""
+gtag: "G-V5Z0Q0HDSM"
 
 # Fill in your Google Analytics ID to track your website using GA
 # google_analytics: ""


### PR DESCRIPTION
Added GA4 gtag (G-V5Z0Q0HDSM) to enable website analytics tracking.

Please note that if you are trying to update **your** website, this is the wrong place to do so. Please carefully follow the Beautiful Jekyll instructions (found at https://github.com/daattali/beautiful-jekyll#readme) and make sure you submit changes to **your** version of the project.

If your intention is to submit a Pull Request, please describe what your pull request achieves.

Thank you!
