### PR TITLE
Add 'Latest Posts' heading so the blog list is easy to find

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1104,6 +1104,18 @@ pre code {
   gap: 4px;
 }
 
+.blog-section-heading {
+  font-family: var(--font-mono);
+  font-size: 15px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-secondary);
+  padding-bottom: 10px;
+  margin: 0 0 24px;
+  border-bottom: 1px solid var(--border);
+}
+
 /* --- Page content card --- */
 
 .page-content-inner,

--- a/index.html
+++ b/index.html
@@ -18,6 +18,8 @@ use-site-title: true
   </div>
 </section>
 
+<h2 class="blog-section-heading">Latest Posts</h2>
+
 <div class="posts-list">
   {% for post in paginator.posts %}
   <article class="post-preview">


### PR DESCRIPTION
## Summary

Makes the blog easier to find on the homepage. The "Blog" navbar link points to the homepage (`index`), and the recently-added hero now sits at the top of that page — so the post list below it had no label and didn't read as "the blog."

Adds a labeled **"Latest Posts"** heading directly above the post list (themed, mono-uppercase with a bottom border), so the blog section is obvious the moment you land there. The RAG article remains the top entry in the list.

## Test plan
- [x] Local Jekyll build succeeds; "Latest Posts" heading renders above the list, with the RAG article as the first post
- [ ] GitHub Pages rebuilds and the heading appears on the live homepage

https://claude.ai/code/session_01DtYcnD6VKoshGrF2RgCbAN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DtYcnD6VKoshGrF2RgCbAN)_